### PR TITLE
Fixes certificates outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "instance_group_urls" {
 }
 
 output "client_certificate" {
-  value       = "${google_container_cluster.new_container_cluster.client_certificate}"
+  value       = "${google_container_cluster.new_container_cluster.master_auth.0.client_certificate}"
   description = "Base64 encoded public certificate that is the root of trust for the cluster"
 }
 
@@ -24,6 +24,6 @@ output "client_key" {
 }
 
 output "cluster_ca_certificate" {
-  value       = "${google_container_cluster.new_container_cluster.cluster_ca_certificate}"
+  value       = "${google_container_cluster.new_container_cluster.master_auth.0.cluster_ca_certificate}"
   description = "Base64 encoded public certificate that is the root of trust for the cluster"
 }


### PR DESCRIPTION
After trying to use the module I've faced two errors:
```
* module.(..).output.cluster_ca_certificate: Resource 'google_container_cluster.new_container_cluster' does not have attribute 'cluster_ca_certificate' for variable 'google_container_cluster.new_container_cluster.cluster_ca_certificate'
* module.(..).output.client_certificate: Resource 'google_container_cluster.new_container_cluster' does not have attribute 'client_certificate' for variable 'google_container_cluster.new_container_cluster.client_certificate'
```

After checking the docs[[1]][[2]], noticed the both errors were caused by the two outputs -- `client_certificate` and `cluster_ca_certificate` -- having the wrong value.

This PR fixes the value of both outputs.

[1]: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_auth-0-client_certificate
[2]: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_auth-0-cluster_ca_certificate